### PR TITLE
HAMT-60: More Voting Tests

### DIFF
--- a/scripts/DeployHamzaVault.s.sol
+++ b/scripts/DeployHamzaVault.s.sol
@@ -243,7 +243,7 @@ contract DeployHamzaVault is Script {
         bytes[] memory initActions = prepareBaalInitActions(pauseSharesOnInit, pauseLootOnInit, sharesToMintForSafe, vault);
 
         // 8) Summon Baal
-        newBaalAddr = summoner.summonBaal(initParams, initActions, uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty))) % 100);
+        newBaalAddr = summoner.summonBaal(initParams, initActions, uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao))) % 100);
 
         // fetch loot token address (Baal's "loot token")
         lootTokenAddr = address(Baal(newBaalAddr).lootToken());


### PR DESCRIPTION
Refactored voting test to use the deployment setup

Added new voting tests to make sure the timelock is enforced, vote delegation works, user needs voting power, no double voting, cancel proposal works as intended, quorum enforced, and abstain vote works as intended. 